### PR TITLE
Remove ini_set of max execution time in Caller constructor

### DIFF
--- a/src/Caller/Infrastructure/Caller.php
+++ b/src/Caller/Infrastructure/Caller.php
@@ -21,7 +21,6 @@ class Caller implements CallerInterface
         private ContextInterface $context,
         private Settings $moduleSettings
     ) {
-        ini_set('max_execution_time', self::CURL_TIMEOUT);
     }
 
     public function fetchReport(): Page


### PR DESCRIPTION
ini_set for max execution time in Caller construct is changing overall execution time limit. This should usually not cause trouble in production environment and we do not need it for current module logic.
It leads our integration tests to time out as the constructor is called when DI container is compiled. Please also backport to 7.0.x branch. 